### PR TITLE
Fix situation where inability to create snapshot would cause a crash

### DIFF
--- a/SnapmakerGCodeWriter.py
+++ b/SnapmakerGCodeWriter.py
@@ -123,14 +123,16 @@ class SnapmakerGCodeWriter(MeshWriter):
             estiTime += int(feature_times[x])
         # Generate snapshot
         self._snapshot = self._createSnapshot()
-        Logger.log("d","Snapshot created.")
-        thumbnail_buffer = QBuffer()
-        thumbnail_buffer.open(QBuffer.ReadWrite)
-        thumbnail_image = self._snapshot
-        thumbnail_image.save(thumbnail_buffer, "PNG")
-        base64_bytes = base64.b64encode(thumbnail_buffer.data())
-        base64_message = base64_bytes.decode('ascii')
-        thumbnail_buffer.close()
+        base64_message = ""
+        if self._snapshot:
+            thumbnail_buffer = QBuffer()
+            thumbnail_buffer.open(QBuffer.ReadWrite)
+            thumbnail_image = self._snapshot
+            thumbnail_image.save(thumbnail_buffer, "PNG")
+            base64_bytes = base64.b64encode(thumbnail_buffer.data())
+            base64_message = base64_bytes.decode('ascii')
+            thumbnail_buffer.close()
+
         # Start header
         stream.write(";Header Start\n\n")
         gcode_buffer = ""

--- a/SnapmakerGCodeWriter.py
+++ b/SnapmakerGCodeWriter.py
@@ -122,7 +122,7 @@ class SnapmakerGCodeWriter(MeshWriter):
             #Logger.log("d",x+":"+str(int(feature_times[x])) + " Seconds")
             estiTime += int(feature_times[x])
         # Generate snapshot
-        self.snapshot = self._createSnapshot()
+        self._snapshot = self._createSnapshot()
         Logger.log("d","Snapshot created.")
         thumbnail_buffer = QBuffer()
         thumbnail_buffer.open(QBuffer.ReadWrite)


### PR DESCRIPTION
I don't actually have a snapmaker, so these changes are made without me actually testing if it works correctly.

We found this issue due to a crash log in sentry. Since the issue seems easy enough to fix, I figured I might as well do a PR for it.

