### PR TITLE
Improve post-upload behavior

### DIFF
--- a/CuraSnapmakerSenderPlugin.py
+++ b/CuraSnapmakerSenderPlugin.py
@@ -393,6 +393,19 @@ class CuraSnapmakerSenderOutputDevice(OutputDevice): #We need an actual device t
             self.writeSuccess.emit()
         else:
             self.writeError.emit()
+
+        print_name = CuraApplication.getInstance().getPrintInformation().jobName
+        message = Message(
+           i18n_catalog.i18nc("@message", "Successfully sent '%s' to %s") % (print_name, self._nameofSnapmaker),
+           lifetime=30,dismissable=True,title='Success')
+        message.show()
+
+        # Disconnect after upload so user can operate printer to select file.
+        self._printer.setBlocking(False)
+        self._printer.disconnect()
+        self._printer.setBlocking(True)
+        self._printer = SnapmakerApiV1.SnapmakerApiV1(self._uri,self._token)
+
     def tearDown(self):
         self._printer.disconnect()
 


### PR DESCRIPTION
This prevents keeping the Snapmaker screen stuck in remote-control mode after the upload, which requires the user to manually disconnect.
Instead, we automatically disconnect and show a success indication in Cura itself instead.﻿
Only downside is a bit of added latency to reconnect if the user makes multiple uploads, but that should be uncommon - most people upload to the machine once and then start printing.